### PR TITLE
Added functionality for hiding windows from taskbar & task switcher(alt+tab) by modifying hide and unhide dllmain.cpp / Added GetLastErrorWithMessage() method in injector code for better error visibility with error code and message / added some comments for readability

### DIFF
--- a/Invisiwind.sln
+++ b/Invisiwind.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31025.194
+# Visual Studio Version 17
+VisualStudioVersion = 17.13.35931.197 d17.13
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "Invisiwind", "Injector\Injector.vcxproj", "{781C8A65-1020-481D-9448-F69EE1D370F4}"
 EndProject

--- a/Misc/inno.iss
+++ b/Misc/inno.iss
@@ -2,7 +2,7 @@
 ; SEE THE DOCUMENTATION FOR DETAILS ON CREATING INNO SETUP SCRIPT FILES!
 
 #define MyAppName "Invisiwind"
-#define MyAppVersion "1.1.4"
+#define MyAppVersion "1.1.6"
 #define MyAppPublisher "Radiantly"
 #define MyAppURL "https://github.com/radiantly/Invisiwind"
 

--- a/Payload/dllmain.cpp
+++ b/Payload/dllmain.cpp
@@ -1,14 +1,46 @@
+//HIDER Dll Code
 #define WIN32_LEAN_AND_MEAN
 
 #include "Windows.h"
 
+//Method to Hide from Screenshare
 void setDAForWindows() {
 	HWND windowHandle = NULL;
 	do {
 		windowHandle = FindWindowEx(NULL, windowHandle, NULL, NULL);
-		SetWindowDisplayAffinity(windowHandle, WDA_EXCLUDEFROMCAPTURE);
+		if (windowHandle) {
+			// Hide from screen capture
+			SetWindowDisplayAffinity(windowHandle, WDA_EXCLUDEFROMCAPTURE);
+		}
 	} while (windowHandle);
 }
+
+//Method to Hide from Taskbar and Alt-Tab Task Switcher
+void setStyleForWindows() {
+	// Get the window handle of the current process
+	DWORD currentProcessId = GetCurrentProcessId();
+	HWND currentWindow = NULL;
+
+	// Find windows belonging to the current process
+	HWND windowHandle = NULL;
+	do {
+		windowHandle = FindWindowEx(NULL, windowHandle, NULL, NULL);
+		if (windowHandle) {
+			DWORD processId = 0;
+			GetWindowThreadProcessId(windowHandle, &processId);
+
+			// Only modify windows from the current process
+			if (processId == currentProcessId) {
+				// Set window styles (add TOOLWINDOW, remove APPWINDOW)
+				LONG_PTR style = GetWindowLongPtr(windowHandle, GWL_EXSTYLE);
+				style &= ~WS_EX_APPWINDOW;  // Remove app window style
+				style |= WS_EX_TOOLWINDOW;  // Add tool window style
+				SetWindowLongPtr(windowHandle, GWL_EXSTYLE, style);
+			}
+		}
+	} while (windowHandle);
+}
+
 
 BOOL APIENTRY DllMain(HMODULE hModule,
 	DWORD  ul_reason_for_call,
@@ -19,6 +51,8 @@ BOOL APIENTRY DllMain(HMODULE hModule,
 	{
 	case DLL_PROCESS_ATTACH:
 		setDAForWindows();
+		setStyleForWindows();
+		break;
 	case DLL_THREAD_ATTACH:
 	case DLL_THREAD_DETACH:
 	case DLL_PROCESS_DETACH:

--- a/Unhide/dllmain.cpp
+++ b/Unhide/dllmain.cpp
@@ -1,14 +1,45 @@
+//UNHIDER Dll Code
 #define WIN32_LEAN_AND_MEAN
 
 #include "Windows.h"
 
+// Method to Unhide from Screenshare
 void setDAForWindows() {
 	HWND windowHandle = NULL;
 	do {
 		windowHandle = FindWindowEx(NULL, windowHandle, NULL, NULL);
-		SetWindowDisplayAffinity(windowHandle, WDA_NONE);
+		if (windowHandle) {
+			// Restore normal display affinity
+			SetWindowDisplayAffinity(windowHandle, WDA_NONE);
+		}
 	} while (windowHandle);
 }
+
+
+// Method to Unhide/Restore Taskbar and Alt-Tab Task Switcher visibility
+void restoreStyleForWindows() {
+	// Get the window handle of the current process
+	DWORD currentProcessId = GetCurrentProcessId();
+	HWND windowHandle = NULL;
+
+	do {
+		windowHandle = FindWindowEx(NULL, windowHandle, NULL, NULL);
+		if (windowHandle) {
+			DWORD processId = 0;
+			GetWindowThreadProcessId(windowHandle, &processId);
+
+			// Only modify windows from the current process
+			if (processId == currentProcessId) {
+				// Restore normal window styles (remove TOOLWINDOW, add APPWINDOW)
+				LONG_PTR style = GetWindowLongPtr(windowHandle, GWL_EXSTYLE);
+				style &= ~WS_EX_TOOLWINDOW;  // Remove tool window style
+				style |= WS_EX_APPWINDOW;    // Add app window style
+				SetWindowLongPtr(windowHandle, GWL_EXSTYLE, style);
+			}
+		}
+	} while (windowHandle);
+}
+
 
 BOOL APIENTRY DllMain(HMODULE hModule,
 	DWORD  ul_reason_for_call,
@@ -19,12 +50,13 @@ BOOL APIENTRY DllMain(HMODULE hModule,
 	{
 	case DLL_PROCESS_ATTACH:
 		setDAForWindows();
+		restoreStyleForWindows();
 		break;
 	case DLL_THREAD_ATTACH:
 	case DLL_THREAD_DETACH:
 	case DLL_PROCESS_DETACH:
 		break;
 	}
-	return FALSE;
+	return FALSE; 
 }
 


### PR DESCRIPTION
### Changes has direct resolution regarding open issue at : [Issue-14](https://github.com/radiantly/Invisiwind/issues/14) and some quality-of-life Improvements.

1.  **Added Functionalites (Files Changed : `Payload/dllmain` and `unhide/dllmain`) :** 
- To hide/unhide windows from taskbar
- To hide/unhide windows from task switcher (alt+tab)
- Both aforementioned functions achive this using style set and unset with `GWL_EXSTYLE` (extended window style) constant provided by Win32 API

2.  **Added Clear Error Handling Capabilities to `injector.cpp` code :**
- Created new method GetLastErrorWithMessage() which refactors on Win32 API function `GetLastError()` in order to show both the error code and messages.
- Used this function inside `wmain()` method's error thrown, to show the error code and message along with our custom error messages
- Errors now shown with greater verbosilty like depicted in below picture
![image](https://github.com/user-attachments/assets/1b5c78a8-cffc-4309-8e80-62473724d238)


3.  **Added `break` after  `DLL_PROCESS_ATTACH` events in  `Payload/dllmain` and `unhide/dllmain` for safer execution**

4.  **Added some comments in code for better readability**

5.  **The `Invisiwind.sln` file is auto-updated with latest visual studio version by the IDE itself, however `MinimumVisualStudioVersion` remains same , promising backward compatibility.**

6. **Modified Inno Installer Script `Misc/inno.iss` with a new semantic versioning number for distinction** 

> To test the changes without merging, you might consider creating a branch before merging to main, or you might use my forked repo here at : https://github.com/aamitn/invisiwind to test it out.


Best Regards,
Amit
